### PR TITLE
[JK] Update success() calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,12 @@ angular.module('yourApp', ['braintree-angular'])
     };
 
     var startup = function() {
-      $braintree.getClientToken().success(function(token) {
+      $braintree.getClientToken().then(function(token) {
         client = new $braintree.api.Client({
-          clientToken: token
+          clientToken: token.data
         });
+      }).catch(function(err) {
+        // handle error
       });
     }
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "braintree-angular-gamersensei",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "homepage": "https://github.com/jlforever/braintree-angular-gamersensei",
   "authors": [
     "Jiapeng Ji <jj@gamersensei.com>"

--- a/dist/braintree-angular.js
+++ b/dist/braintree-angular.js
@@ -78,21 +78,21 @@ function braintreeFactory (braintree) {
 
     $braintree.setupDropin = function (options) {
       $braintree.getClientToken()
-        .success(function (token) {
-          braintree.setup(token, 'dropin', options)
+        .then(function (token) {
+          braintree.setup(token.data, 'dropin', options)
         })
-        .error(function (data, status) {
-          console.error('error fetching client token at ' + clientTokenPath, data, status)
+        .catch(function (err, status) {
+          console.error('error fetching client token at ' + clientTokenPath, err.data, status)
         })
     }
 
     $braintree.setupPayPal = function (options) {
       $braintree.getClientToken()
-        .success(function (token) {
-          braintree.setup(token, 'paypal', options)
+        .then(function (token) {
+          braintree.setup(token.data, 'paypal', options)
         })
-        .error(function (data, status) {
-          console.error('error fetching client token at ' + clientTokenPath, data, status)
+        .error(function (err, status) {
+          console.error('error fetching client token at ' + clientTokenPath, err.data, status)
         })
     }
 

--- a/lib/braintree-factory.js
+++ b/lib/braintree-factory.js
@@ -25,21 +25,21 @@ function braintreeFactory (braintree) {
 
     $braintree.setupDropin = function (options) {
       $braintree.getClientToken()
-        .success(function (token) {
-          braintree.setup(token, 'dropin', options)
+        .then(function (token) {
+          braintree.setup(token.data, 'dropin', options)
         })
-        .error(function (data, status) {
-          console.error('error fetching client token at ' + clientTokenPath, data, status)
+        .catch(function (err, status) {
+          console.error('error fetching client token at ' + clientTokenPath, err.data, status)
         })
     }
 
     $braintree.setupPayPal = function (options) {
       $braintree.getClientToken()
-        .success(function (token) {
-          braintree.setup(token, 'paypal', options)
+        .then(function (token) {
+          braintree.setup(token.data, 'paypal', options)
         })
-        .error(function (data, status) {
-          console.error('error fetching client token at ' + clientTokenPath, data, status)
+        .error(function (err, status) {
+          console.error('error fetching client token at ' + clientTokenPath, err.data, status)
         })
     }
 

--- a/test/support/test-advanced.html
+++ b/test/support/test-advanced.html
@@ -17,17 +17,17 @@
         .controller('testCtrl', ['$braintree', function($braintree) {
 
           $braintree.getClientToken()
-            .success(function(token) {
+            .then(function(token) {
 
               var client = new $braintree.api.Client({
-                clientToken: token
+                clientToken: token.data
               });
 
               if (client.tokenizeCard) {
                 window.braintreeApiInitialized = true;
               }
 
-            });
+            }).catch(function(err) {});
 
         }]);
     </script>


### PR DESCRIPTION
`.success()` has been deprecated for a while, and officially removed from angular starting from v 1.6. This converts from `.success()` and `.error()` to `.then()` and `.catch()`.